### PR TITLE
fix: prevent maximum call stack size exceeded

### DIFF
--- a/src/bunders/esbuild.ts
+++ b/src/bunders/esbuild.ts
@@ -1,10 +1,6 @@
 import { build, transform } from 'esbuild'
 import { Bundler } from './base'
 
-function uint8arrayToStringMethod(myUint8Arr: Uint8Array) {
-  return String.fromCharCode.apply(null, myUint8Arr)
-}
-
 export class ESBuildBundler extends Bundler {
   name = 'esbuild'
   async start() {
@@ -28,10 +24,9 @@ export class ESBuildBundler extends Bundler {
         },
         mainFields: ['module', 'browser', 'main'],
         external: this.external,
+        legalComments: 'none',
       })
-      const bundled = uint8arrayToStringMethod(bundledResult.outputFiles[0].contents)
-        .replace(/\/\*[\s\S]*?\*\/\n?/mg, '') // remove comments
-
+      const bundled = bundledResult.outputFiles[0].text
       const minifiedResult = await transform(bundled, { minify: true, format: 'esm', loader: 'js' })
       const minified = minifiedResult.code
       return {


### PR DESCRIPTION
Decode a <samp>Uint8Array</samp> using <samp>String.fromCharCode.apply</samp> will cause <samp>RangeError: Maximum call stack size exceeded</samp> if the content is too long, e.g. dealing with a 1.4MB package.

```js
> String.fromCharCode.apply(null, Uint8Array.from(Array(1000000)))
Uncaught RangeError: Maximum call stack size exceeded
```

The best way is using <samp> TextDecoder</samp>, which esbuild has done in its <samp>get text()</samp> property.

I also added <samp>legalComments: 'none'</samp> to prevent removing comments by ourself.